### PR TITLE
update crates for rustc 1.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "rust-wc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Matthew Nicholson <matt@matt-land.com>"]
 
 [dependencies]
-getopts = "0.2"
-memmap = "0.2"
-byteorder = "0.4"
+getopts = "0.2.14"
+memmap = "0.4.0"
+byteorder = "0.5.3"


### PR DESCRIPTION
Otherwise crate fs2 will not compile.
